### PR TITLE
Grid map sensor extension

### DIFF
--- a/l3_terrain_model_generator/CMakeLists.txt
+++ b/l3_terrain_model_generator/CMakeLists.txt
@@ -77,6 +77,7 @@ set(HEADERS
   include/${PROJECT_NAME}/plugins/std/filter/pcl_pass_through_ellipse_filter.h
   include/${PROJECT_NAME}/plugins/std/filter/pcl_statistical_outlier_filter.h
   include/${PROJECT_NAME}/plugins/std/filter/pcl_voxel_grid_filter.h
+  include/${PROJECT_NAME}/plugins/std/generator/copy_map_layer_generator.h
   include/${PROJECT_NAME}/plugins/std/generator/edges_cloud_generator.h
   include/${PROJECT_NAME}/plugins/std/generator/elevation_map_generator.h
   include/${PROJECT_NAME}/plugins/std/generator/gradients_cloud_generator.h
@@ -131,6 +132,7 @@ set(SOURCES
   src/plugins/std/filter/pcl_pass_through_ellipse_filter.cpp
   src/plugins/std/filter/pcl_statistical_outlier_filter.cpp
   src/plugins/std/filter/pcl_voxel_grid_filter.cpp
+  src/plugins/std/generator/copy_map_layer_generator.cpp
   src/plugins/std/generator/edges_cloud_generator.cpp
   src/plugins/std/generator/elevation_map_generator.cpp
   src/plugins/std/generator/gradients_cloud_generator.cpp

--- a/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/base/sensor_plugin.h
+++ b/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/base/sensor_plugin.h
@@ -76,7 +76,7 @@ public:
 
   /**
    * @brief Returns configured sensor frame, which represents the location of the sensor
-   * devive and thus the origin of the data.
+   * device and thus the origin of the data.
    * @return Sensor frame id
    */
   inline const std::string& getSensorFrame() const { return sensor_frame_id_; }

--- a/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/std/generator/copy_map_layer_generator.h
+++ b/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/std/generator/copy_map_layer_generator.h
@@ -1,0 +1,55 @@
+//=================================================================================================
+// Copyright (c) 2025, Alexander Stumpf, TU Darmstadt
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the Simulation, Systems Optimization and Robotics
+//       group, TU Darmstadt nor the names of its contributors may be used to
+//       endorse or promote products derived from this software without
+//       specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//=================================================================================================
+
+#pragma once
+
+#include <l3_terrain_model_generator/plugins/base/generator_plugin.h>
+
+namespace l3_terrain_modeling
+{
+class CopyMapLayerGenerator : public GeneratorPlugin
+{
+public:
+  // typedefs
+  typedef l3::SharedPtr<CopyMapLayerGenerator> Ptr;
+  typedef l3::SharedPtr<const CopyMapLayerGenerator> ConstPtr;
+
+  CopyMapLayerGenerator();
+
+  bool loadParams(const vigir_generic_params::ParameterSet& params) override;
+
+  bool postInitialize(const vigir_generic_params::ParameterSet& params) override;
+
+protected:
+  void update(const Timer& timer, UpdatedHandles& updates, const SensorPlugin* sensor) override;
+
+  DataHandle::Ptr grid_map_handle_;
+  std::string in_layer_;
+  std::string out_layer_;
+};
+}  // namespace l3_terrain_modeling

--- a/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/std/sensor/grid_map_sensor.h
+++ b/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/std/sensor/grid_map_sensor.h
@@ -69,7 +69,8 @@ private:
   DataHandle::Ptr grid_cell_updates_handle_;
   PclDataHandle<pcl::PointCloud>::Ptr cloud_pcl_handle_;
 
-  std::string layer_;
+  std::string input_layer_;
+  std::string output_layer_;
 
   bool provide_grid_cell_updates_;
   bool provide_cloud_;

--- a/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/std/sensor/grid_map_sensor.h
+++ b/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/std/sensor/grid_map_sensor.h
@@ -69,8 +69,8 @@ private:
   DataHandle::Ptr grid_cell_updates_handle_;
   PclDataHandle<pcl::PointCloud>::Ptr cloud_pcl_handle_;
 
-  std::string input_layer_;
-  std::string output_layer_;
+  std::string in_layer_;
+  std::string out_layer_;
 
   bool provide_grid_cell_updates_;
   bool provide_cloud_;

--- a/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/std/sensor/grid_map_sensor.h
+++ b/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/std/sensor/grid_map_sensor.h
@@ -65,9 +65,14 @@ public:
 private:
   void gridMapCb(const grid_map_msgs::GridMap& msg);
 
+  DataHandle::Ptr grid_map_handle_;
+  DataHandle::Ptr grid_cell_updates_handle_;
   PclDataHandle<pcl::PointCloud>::Ptr cloud_pcl_handle_;
 
   std::string layer_;
+
+  bool provide_grid_cell_updates_;
+  bool provide_cloud_;
 
   ros::Subscriber grid_map_sub_;
 };

--- a/l3_terrain_model_generator/include/l3_terrain_model_generator/utils/macros.h
+++ b/l3_terrain_model_generator/include/l3_terrain_model_generator/utils/macros.h
@@ -117,7 +117,7 @@
 
 /**
  * @brief Helper macros to get handle to existing data.
- * @param Type Data type accessed by the handle
+ * @param Data Default Data to initialize the handle if not found
  * @param ParamKey Parameter key to look up for alternative handle name in the parameter set (located in "data/out/<ParamKey>")
  * @param DefaultHandleName Default handle name
  * @param Handle [Out] handle
@@ -136,7 +136,7 @@
 
 /**
  * @brief Helper macros to get (new) handle to data. Assumes that the parameter key is "data".
- * @param Type Data type accessed by the handle
+ * @param Data Default Data to initialize the handle if not found
  * @param DefaultHandleName Default handle name
  * @param Handle [Out] handle
  */

--- a/l3_terrain_model_generator/plugins.xml
+++ b/l3_terrain_model_generator/plugins.xml
@@ -65,6 +65,12 @@
 
   <!-- Generator plugins -->
 
+  <class name="copy_map_layer_generator" type="l3_terrain_modeling::CopyMapLayerGenerator" base_class_type="l3_terrain_modeling::ProcessorPlugin">
+    <description>
+      Copies over a layer to another layer within a grid map.
+    </description>
+  </class>
+
   <class name="elevation_map_generator" type="l3_terrain_modeling::ElevationMapGenerator" base_class_type="l3_terrain_modeling::ProcessorPlugin">
     <description>
       Generates a elevation map based on input point cloud.

--- a/l3_terrain_model_generator/src/plugins/base/point_cloud_sensor_plugin.cpp
+++ b/l3_terrain_model_generator/src/plugins/base/point_cloud_sensor_plugin.cpp
@@ -11,7 +11,7 @@ bool PointCloudSensorPlugin::initialize(const vigir_generic_params::ParameterSet
   if (!SensorPlugin::initialize(params))
     return false;
 
-  GET_OUTPUT_PCL_HANDLE("data", "cloud", "PointXYZ", cloud_pcl_handle_);
+  GET_OUTPUT_PCL_HANDLE_DEFAULT("cloud", cloud_pcl_handle_);
 
   return true;
 }

--- a/l3_terrain_model_generator/src/plugins/base/sensor_plugin.cpp
+++ b/l3_terrain_model_generator/src/plugins/base/sensor_plugin.cpp
@@ -61,7 +61,7 @@ bool SensorPlugin::postInitialize(const vigir_generic_params::ParameterSet& para
 void SensorPlugin::updateSensorPose(const Time& time)
 {
   ros::Time ros_time = Timer::timeToRos(time);
-  getTransformAsPose(tf_buffer_, getMapFrame(), sensor_frame_id_, ros_time, sensor_pose_);
+  getTransformAsPose(tf_buffer_, getMapFrame(), getSensorFrame(), ros_time, sensor_pose_);
 }
 
 void SensorPlugin::process(const Time& time, UpdatedHandles::Ptr updates)

--- a/l3_terrain_model_generator/src/plugins/std/generator/copy_map_layer_generator.cpp
+++ b/l3_terrain_model_generator/src/plugins/std/generator/copy_map_layer_generator.cpp
@@ -1,0 +1,49 @@
+#include <l3_terrain_model_generator/plugins/std/generator/copy_map_layer_generator.h>
+
+#include <grid_map_core/GridMapMath.hpp>
+
+#include <l3_terrain_model/typedefs.h>
+
+namespace l3_terrain_modeling
+{
+CopyMapLayerGenerator::CopyMapLayerGenerator()
+  : GeneratorPlugin("copy_map_layer_generator")
+{}
+
+bool CopyMapLayerGenerator::loadParams(const vigir_generic_params::ParameterSet& params)
+{
+  if (!GeneratorPlugin::loadParams(params))
+    return false;
+
+  in_layer_ = param("in_layer", ELEVATION_LAYER, true);
+  out_layer_ = param("out_layer", ELEVATION_LAYER + "_copy", false);
+
+  return true;
+}
+
+bool CopyMapLayerGenerator::postInitialize(const vigir_generic_params::ParameterSet& params)
+{
+  if (!GeneratorPlugin::postInitialize(params))
+    return false;
+
+  GET_INPUT_HANDLE_DEFAULT(grid_map::GridMap, "grid_map", grid_map_handle_);
+
+  l3::UniqueLockPtr lock;
+  grid_map::GridMap& grid_map = grid_map_handle_->value<grid_map::GridMap>(lock);
+
+  grid_map.add(out_layer_);
+
+  return true;
+}
+
+void CopyMapLayerGenerator::update(const Timer& timer, UpdatedHandles& updates, const SensorPlugin* sensor)
+{
+  l3::UniqueLockPtr lock;
+  grid_map::GridMap& grid_map = grid_map_handle_->value<grid_map::GridMap>(lock);
+
+  grid_map.add(out_layer_, grid_map.get(in_layer_));
+}
+}  // namespace l3_terrain_modeling
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(l3_terrain_modeling::CopyMapLayerGenerator, l3_terrain_modeling::ProcessorPlugin)

--- a/l3_terrain_model_generator/src/plugins/std/sensor/grid_map_sensor.cpp
+++ b/l3_terrain_model_generator/src/plugins/std/sensor/grid_map_sensor.cpp
@@ -13,8 +13,8 @@ bool GridMapSensor::loadParams(const vigir_generic_params::ParameterSet& params)
   if (!SensorPlugin::loadParams(params))
     return false;
 
-  input_layer_ = param("in_layer", ELEVATION_LAYER, true);
-  output_layer_ = param("out_layer", output_layer_, true);
+  in_layer_ = param("in_layer", ELEVATION_LAYER, true);
+  out_layer_ = param("out_layer", out_layer_, true);
   provide_grid_cell_updates_ = param("provide_grid_cell_updates", false, true);
   provide_cloud_ = param("provide_cloud", false, true);
 
@@ -76,9 +76,9 @@ void GridMapSensor::gridMapCb(const grid_map_msgs::GridMap& msg)
   // convert msg to grid map
   l3::UniqueLockPtr lock;
   grid_map::GridMap& grid_map = grid_map_handle_->value<grid_map::GridMap>(lock);
-  grid_map::GridMapRosConverter::fromMessage(msg, grid_map, { input_layer_ });
-  if (input_layer_ != output_layer_)
-    grid_map.add(output_layer_, grid_map.get(input_layer_));
+  grid_map::GridMapRosConverter::fromMessage(msg, grid_map, { in_layer_ });
+  if (in_layer_ != out_layer_)
+    grid_map.add(out_layer_, grid_map.get(in_layer_));
 
   l3::SharedPtr<UpdatedHandles> updated_handles = l3::makeShared<UpdatedHandles>(std::initializer_list<DataHandle::ConstPtr>{ grid_map_handle_ });
 
@@ -100,7 +100,7 @@ void GridMapSensor::gridMapCb(const grid_map_msgs::GridMap& msg)
       GridCell cell;
       cell.position.x() = position.x();
       cell.position.y() = position.y();
-      cell.position.z() = grid_map.at(input_layer_, index);
+      cell.position.z() = grid_map.at(in_layer_, index);
 
       grid_cell_updates.cells.push_back(cell);
     }
@@ -112,7 +112,7 @@ void GridMapSensor::gridMapCb(const grid_map_msgs::GridMap& msg)
   if (provide_cloud_)
   {
     sensor_msgs::PointCloud2 point_cloud_msg;
-    grid_map::GridMapRosConverter::toPointCloud(grid_map, input_layer_, point_cloud_msg);
+    grid_map::GridMapRosConverter::toPointCloud(grid_map, in_layer_, point_cloud_msg);
     point_cloud_msg.header.frame_id = getMapFrame();
     point_cloud_msg.header.stamp = ros::Time::now();
 

--- a/l3_terrain_model_generator/src/plugins/std/sensor/grid_map_sensor.cpp
+++ b/l3_terrain_model_generator/src/plugins/std/sensor/grid_map_sensor.cpp
@@ -78,11 +78,7 @@ void GridMapSensor::gridMapCb(const grid_map_msgs::GridMap& msg)
   grid_map::GridMap& grid_map = grid_map_handle_->value<grid_map::GridMap>(lock);
   grid_map::GridMapRosConverter::fromMessage(msg, grid_map, { input_layer_ });
   if (input_layer_ != output_layer_)
-  {
-    if (grid_map.exists(output_layer_))
-      ROS_WARN_THROTTLE(1.0, "[%s] Output layer \"%s\" already exists in grid map!", getName().c_str(), output_layer_.c_str());
-    grid_map.add(output_layer_, grid_map[input_layer_]);
-  }
+    grid_map.add(output_layer_, grid_map.get(input_layer_));
 
   l3::SharedPtr<UpdatedHandles> updated_handles = l3::makeShared<UpdatedHandles>(std::initializer_list<DataHandle::ConstPtr>{ grid_map_handle_ });
 

--- a/l3_terrain_model_generator/src/plugins/std/sensor/grid_map_sensor.cpp
+++ b/l3_terrain_model_generator/src/plugins/std/sensor/grid_map_sensor.cpp
@@ -13,8 +13,8 @@ bool GridMapSensor::loadParams(const vigir_generic_params::ParameterSet& params)
   if (!SensorPlugin::loadParams(params))
     return false;
 
-  input_layer_ = param("input_layer", ELEVATION_LAYER, true);
-  output_layer_ = param("output_layer", output_layer_, true);
+  input_layer_ = param("in_layer", ELEVATION_LAYER, true);
+  output_layer_ = param("out_layer", output_layer_, true);
   provide_grid_cell_updates_ = param("provide_grid_cell_updates", false, true);
   provide_cloud_ = param("provide_cloud", false, true);
 

--- a/l3_terrain_model_generator/src/plugins/std/sensor/grid_map_sensor.cpp
+++ b/l3_terrain_model_generator/src/plugins/std/sensor/grid_map_sensor.cpp
@@ -13,7 +13,9 @@ bool GridMapSensor::loadParams(const vigir_generic_params::ParameterSet& params)
   if (!SensorPlugin::loadParams(params))
     return false;
 
-  layer_ = param("layer", std::string("elevation"), true);
+  layer_ = param("layer", ELEVATION_LAYER, true);
+  provide_grid_cell_updates_ = param("provide_grid_cell_updates", false, true);
+  provide_cloud_ = param("provide_cloud", false, true);
 
   return true;
 }
@@ -23,9 +25,41 @@ bool GridMapSensor::initialize(const vigir_generic_params::ParameterSet& params)
   if (!SensorPlugin::initialize(params))
     return false;
 
-  GET_OUTPUT_PCL_HANDLE_DEFAULT("cloud", cloud_pcl_handle_);
+  // pre set map properties so other dependend plugins can check for it
+  const std::string& map_frame_id = param("map_frame", std::string("map"), true);
+  std::vector<int> size = param("size", std::vector<int>{1, 1}, true);
+  if (size.size() != 2)
+  {
+    ROS_ERROR("[%s] Initialization failed! Parameter \"size\" must be a vector of size 2!", getName().c_str());
+    return false;
+  }
+  double resolution = param("resolution", 0.01);
 
-  std::string topic = param("topic", ELEVATION_LAYER, true);
+  grid_map::GridMap grid_map;
+  grid_map.setFrameId(map_frame_id);
+  grid_map.setGeometry(grid_map::Length(size[0], size[1]), resolution);
+  grid_map.setTimestamp(ros::Time::now().toNSec());
+
+  // init grid map handle
+  const std::string& grid_map_output_data_name = getOutputDataParam(getParams(), "grid_map", GRID_MAP_NAME);
+  GET_OUTPUT_HANDLE(grid_map, grid_map_output_data_name, "grid_map", grid_map_handle_);
+
+  // init grid cell updates handle
+  if (provide_grid_cell_updates_)
+  {
+    const std::string& grid_map_cell_updates_output_data_name = getOutputDataParam(getParams(), "grid_map_cell_updates", GRID_MAP_NAME + "_cell_updates");
+    GET_OUTPUT_HANDLE(GridCellUpdates(), grid_map_cell_updates_output_data_name, "grid_cell_updates", grid_cell_updates_handle_);
+  }
+
+  // init cloud handle
+  if (provide_cloud_)
+  {
+    const std::string& grid_map_cloud_output_data_name = getOutputDataParam(getParams(), "grid_map_cloud", GRID_MAP_NAME + "_cloud");
+    GET_OUTPUT_PCL_HANDLE(grid_map_cloud_output_data_name, "cloud", "PointXYZ", cloud_pcl_handle_);
+  }
+
+  // subscribe to grid map topic
+  std::string topic = param("topic", std::string("/grid_map"), true);
   grid_map_sub_ = nh_.subscribe(topic, 1, &GridMapSensor::gridMapCb, this);
 
   return true;
@@ -36,23 +70,60 @@ void GridMapSensor::gridMapCb(const grid_map_msgs::GridMap& msg)
   if (msg.data.empty())
     return;
 
+  ros::Time time = msg.info.header.stamp;
+
   // convert msg to grid map
-  grid_map::GridMap input_map;
-  grid_map::GridMapRosConverter::fromMessage(msg, input_map, { layer_ });
+  l3::UniqueLockPtr lock;
+  grid_map::GridMap& grid_map = grid_map_handle_->value<grid_map::GridMap>(lock);
+  grid_map::GridMapRosConverter::fromMessage(msg, grid_map, { layer_ });
+
+  l3::SharedPtr<UpdatedHandles> updated_handles = l3::makeShared<UpdatedHandles>(std::initializer_list<DataHandle::ConstPtr>{ grid_map_handle_ });
+
+  // convert grid map to grid cell updates
+  if (provide_grid_cell_updates_)
+  {
+    l3::UniqueLockPtr lock;
+    GridCellUpdates& grid_cell_updates = grid_cell_updates_handle_->value<GridCellUpdates>(lock);
+
+    grid_cell_updates.header = msg.info.header;
+    grid_cell_updates.cells.clear();
+
+    for (grid_map::GridMapIterator iterator(grid_map); !iterator.isPastEnd(); ++iterator)
+    {
+      const grid_map::Index index(*iterator);
+      grid_map::Position position;
+      grid_map.getPosition(index, position);
+
+      GridCell cell;
+      cell.position.x() = position.x();
+      cell.position.y() = position.y();
+      cell.position.z() = grid_map.at(layer_, index);
+
+      grid_cell_updates.cells.push_back(cell);
+    }
+
+    updated_handles->insert(grid_cell_updates_handle_);
+  }
 
   // convert grid map to point cloud
-  sensor_msgs::PointCloud2 point_cloud_msg;
-  grid_map::GridMapRosConverter::toPointCloud(input_map, layer_, point_cloud_msg);
-  point_cloud_msg.header.frame_id = getMapFrame();
-  point_cloud_msg.header.stamp = ros::Time::now();
+  if (provide_cloud_)
+  {
+    sensor_msgs::PointCloud2 point_cloud_msg;
+    grid_map::GridMapRosConverter::toPointCloud(grid_map, layer_, point_cloud_msg);
+    point_cloud_msg.header.frame_id = getMapFrame();
+    point_cloud_msg.header.stamp = ros::Time::now();
 
-  // update pointcloud
-  cloud_pcl_handle_->dispatch<l3::UniqueLock>(
-      [&](auto& cloud, auto type_trait) { pcl::fromROSMsg(point_cloud_msg, *cloud); });
+    // update pointcloud
+    cloud_pcl_handle_->dispatch<l3::UniqueLock>(
+        [&](auto& cloud, auto type_trait) { pcl::fromROSMsg(point_cloud_msg, *cloud); });
+
+    updated_handles->insert(cloud_pcl_handle_->handle());
+  }
+
+  lock->unlock();
 
   // call default processing pipeline
-  SensorPlugin::process(Timer::timeFromRos(point_cloud_msg.header.stamp),
-                        l3::makeShared<UpdatedHandles>(std::initializer_list<DataHandle::ConstPtr>{ cloud_pcl_handle_->handle() }));
+  SensorPlugin::process(Timer::timeFromRos(time), updated_handles);
 }
 }  // namespace l3_terrain_modeling
 

--- a/l3_terrain_model_generator/src/utils/utils.cpp
+++ b/l3_terrain_model_generator/src/utils/utils.cpp
@@ -6,6 +6,12 @@ namespace l3_terrain_modeling
 {
 bool getTransformAsPose(const tf2_ros::Buffer& tf_buffer, const std::string& target_frame, const std::string& source_frame, const ros::Time& time, l3::Pose& pose)
 {
+  if (tf::strip_leading_slash(source_frame) == tf::strip_leading_slash(target_frame))
+  {
+    pose = l3::Pose();
+    return true;
+  }
+
   std::string error_msg;
   if (tf_buffer.canTransform(target_frame, source_frame, time, ros::Duration(1.0), &error_msg))
   {

--- a/l3_terrain_model_generator/src/utils/utils.cpp
+++ b/l3_terrain_model_generator/src/utils/utils.cpp
@@ -7,7 +7,7 @@ namespace l3_terrain_modeling
 bool getTransformAsPose(const tf2_ros::Buffer& tf_buffer, const std::string& target_frame, const std::string& source_frame, const ros::Time& time, l3::Pose& pose)
 {
   std::string error_msg;
-  if (tf_buffer.canTransform(target_frame, source_frame, time, ros::Duration(0.1), &error_msg))
+  if (tf_buffer.canTransform(target_frame, source_frame, time, ros::Duration(1.0), &error_msg))
   {
     geometry_msgs::TransformStamped transform_msg = tf_buffer.lookupTransform(target_frame, source_frame, time);
     l3::transformMsgToL3(transform_msg.transform, pose);


### PR DESCRIPTION
Extends grid map sensor to subscribe existing grid map topics and provide the grid map layer(s) downstream to all processors.
Add CopyGridMapLayer plugin to duplicate layers using a different layer_id.