### PR TITLE
Fix negative obstacle thresholding

### DIFF
--- a/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/std/generator/occupancy_map_generator.h
+++ b/l3_terrain_model_generator/include/l3_terrain_model_generator/plugins/std/generator/occupancy_map_generator.h
@@ -77,7 +77,8 @@ protected:
   float max_height_;
 
   bool binarize_;
-  int binary_threshold_;
+  int upper_threshold_;
+  int lower_threshold_;
 
   bool publish_debug_map_;
 

--- a/l3_terrain_model_generator/src/plugins/std/generator/occupancy_map_generator.cpp
+++ b/l3_terrain_model_generator/src/plugins/std/generator/occupancy_map_generator.cpp
@@ -29,21 +29,27 @@ bool OccupancyMapGenerator::loadParams(const vigir_generic_params::ParameterSet&
 
   binarize_ = param("binarize", true, true);
 
-  if (getParam("binary_threshold", upper_threshold_, 50, true))
-    ROS_WARN("[%s] Parameter \"binary_threshold\" is deprecated, please use \"upper_threshold\" and \"lower_threshold\" instead!", getName().c_str());
-
-  // Get thresholds in meters and convert to percentage of the height range
-  float upper_threshold_abs;
-  if (getParam("upper_threshold", upper_threshold_abs, 0.5f, true))  // Upper threshold in meters
-    upper_threshold_ = static_cast<int>(std::round((upper_threshold_abs - min_height_) / (max_height_ - min_height_) * 100.0f));
+  if (getParam("binary_threshold", upper_threshold_, 100, true))
+  {
+    lower_threshold_ = 0;
+  }
   else
-    upper_threshold_ = 100; // Default to 100 if not set
+  {
+    // Get thresholds in meters and convert to percentage of the height range
+    float upper_threshold_abs;
+    if (getParam("upper_threshold", upper_threshold_abs, 0.5f, true))  // Upper threshold in meters
+      upper_threshold_ = static_cast<int>(std::round((upper_threshold_abs - min_height_) / (max_height_ - min_height_) * 100.0f));
+    else
+      upper_threshold_ = 100; // Default to 100 if not set
 
-  float lower_threshold_abs;
-  if (getParam("lower_threshold", lower_threshold_abs, -0.1f, true))  // Lower threshold in meters
-    lower_threshold_ = static_cast<int>(std::round((lower_threshold_abs - min_height_) / (max_height_ - min_height_) * 100.0f));
-  else
-    lower_threshold_ = 0; // Default to 0 if not set
+    float lower_threshold_abs;
+    if (getParam("lower_threshold", lower_threshold_abs, -0.1f, true))  // Lower threshold in meters
+      lower_threshold_ = static_cast<int>(std::round((lower_threshold_abs - min_height_) / (max_height_ - min_height_) * 100.0f));
+    else
+      lower_threshold_ = 0; // Default to 0 if not set
+  }
+
+  ROS_WARN("Thresholds set to: lower = %d, upper = %d", lower_threshold_, upper_threshold_);
 
   publish_debug_map_ = param("publish_debug_map", false, true);
 

--- a/l3_terrain_model_generator/src/plugins/std/generator/occupancy_map_generator.cpp
+++ b/l3_terrain_model_generator/src/plugins/std/generator/occupancy_map_generator.cpp
@@ -24,11 +24,26 @@ bool OccupancyMapGenerator::loadParams(const vigir_generic_params::ParameterSet&
   use_z_ref_frame_ = param("use_z_ref_frame", true, true);
   transform_to_ref_frame_ = param("transform_to_ref_frame", false, true);
 
-  min_height_ = param("min_height", -0.1, true);
+  min_height_ = param("min_height", -0.3, true);
   max_height_ = param("max_height", 0.9, true);
 
   binarize_ = param("binarize", true, true);
-  binary_threshold_ = param("binary_threshold", 50, true);
+
+  if (getParam("binary_threshold", upper_threshold_, 50, true))
+    ROS_WARN("[%s] Parameter \"binary_threshold\" is deprecated, please use \"upper_threshold\" and \"lower_threshold\" instead!", getName().c_str());
+
+  // Get thresholds in meters and convert to percentage of the height range
+  float upper_threshold_abs;
+  if (getParam("upper_threshold", upper_threshold_abs, 0.5f, true))  // Upper threshold in meters
+    upper_threshold_ = static_cast<int>(std::round((upper_threshold_abs - min_height_) / (max_height_ - min_height_) * 100.0f));
+  else
+    upper_threshold_ = 50; // Default to 50 if not set
+
+  float lower_threshold_abs;
+  if (getParam("lower_threshold", lower_threshold_abs, -0.1f, true))  // Lower threshold in meters
+    lower_threshold_ = static_cast<int>(std::round((lower_threshold_abs - min_height_) / (max_height_ - min_height_) * 100.0f));
+  else
+    lower_threshold_ = 0; // Default to 0 if not set
 
   publish_debug_map_ = param("publish_debug_map", false, true);
 
@@ -223,7 +238,8 @@ void OccupancyMapGenerator::toBinaryOccupancyGrid(nav_msgs::OccupancyGrid& occup
 {
   std::transform(occupancy_map.data.begin(), occupancy_map.data.end(), occupancy_map.data.begin(),
     [this](int8_t value) {
-      return value > binary_threshold_ ? 100 : 0;
+      // Mark as occupied if value is above the upper threshold or below the lower threshold
+      return ((value > 0 && value < lower_threshold_) || value > upper_threshold_) ? 100 : 0;
     }
   );
 }

--- a/l3_terrain_model_generator/src/plugins/std/generator/occupancy_map_generator.cpp
+++ b/l3_terrain_model_generator/src/plugins/std/generator/occupancy_map_generator.cpp
@@ -24,6 +24,9 @@ bool OccupancyMapGenerator::loadParams(const vigir_generic_params::ParameterSet&
   use_z_ref_frame_ = param("use_z_ref_frame", true, true);
   transform_to_ref_frame_ = param("transform_to_ref_frame", false, true);
 
+  // Thresholding can be either done using absolute height values (in meters), when
+  // upper_threshold and lower_threshold are set. Using the single binary_threshold
+  // represents a threshold in percentage of the height range between min_height and max_height.
   min_height_ = param("min_height", -0.3, true);
   max_height_ = param("max_height", 0.9, true);
 
@@ -48,8 +51,6 @@ bool OccupancyMapGenerator::loadParams(const vigir_generic_params::ParameterSet&
     else
       lower_threshold_ = 0; // Default to 0 if not set
   }
-
-  ROS_WARN("Thresholds set to: lower = %d, upper = %d", lower_threshold_, upper_threshold_);
 
   publish_debug_map_ = param("publish_debug_map", false, true);
 

--- a/l3_terrain_model_generator/src/plugins/std/generator/occupancy_map_generator.cpp
+++ b/l3_terrain_model_generator/src/plugins/std/generator/occupancy_map_generator.cpp
@@ -37,7 +37,7 @@ bool OccupancyMapGenerator::loadParams(const vigir_generic_params::ParameterSet&
   if (getParam("upper_threshold", upper_threshold_abs, 0.5f, true))  // Upper threshold in meters
     upper_threshold_ = static_cast<int>(std::round((upper_threshold_abs - min_height_) / (max_height_ - min_height_) * 100.0f));
   else
-    upper_threshold_ = 50; // Default to 50 if not set
+    upper_threshold_ = 100; // Default to 100 if not set
 
   float lower_threshold_abs;
   if (getParam("lower_threshold", lower_threshold_abs, -0.1f, true))  // Lower threshold in meters


### PR DESCRIPTION
Change plugin to use lower and upper bounds to threshold the grid map. Parameters are now in SI units.